### PR TITLE
Publish typescript types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 parity
 
 node_modules
+dist
 
 #Buidler files
 cache

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Javascript deployer for CREATE2 ethereum contracts.",
   "homepage": "https://github.com/thegostep/solidity-create2-deployer",
   "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
   "engines": {
     "node": ">=10"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
+    "declaration": true,
     "outDir": "dist"
   },
   "include": ["test", "./artifacts/**/*.json"],


### PR DESCRIPTION
I've started written a typescript package that depends on this one and would really appreciate if the types were just directly available, so, given that this has already been written in typescript, I made a few minor modifications that will make the compiler generate declaration files, which should then get published on the npm package.